### PR TITLE
다중 토큰 jwt

### DIFF
--- a/src/main/java/com/example/securityserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/securityserver/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.securityserver.config;
 import com.example.securityserver.jwt.JWTFilter;
 import com.example.securityserver.jwt.JWTUtil;
 import com.example.securityserver.jwt.LoginFilter;
+import com.example.securityserver.util.RefreshUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -21,11 +22,13 @@ public class SecurityConfig {
     //AuthenticationManager가 인자로 받을 AuthenticationConfiguraion 객체 생성자 주입
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JWTUtil jwtUtil;
+    private final RefreshUtil refreshUtil;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil, RefreshUtil refreshUtil) {
 
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtUtil = jwtUtil;
+        this.refreshUtil = refreshUtil;
     }
 
     //AuthenticationManager Bean 등록
@@ -59,7 +62,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join", "/reissue").permitAll()
+                        .requestMatchers("/auth/login", "/", "/auth/join", "/reissue").permitAll()
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated());
 
@@ -69,7 +72,7 @@ public class SecurityConfig {
 
         //필터 추가 LoginFilter()는 인자를 받음 (AuthenticationManager() 메소드에 authenticationConfiguration 객체를 넣어야 함) 따라서 등록 필요
         http
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshUtil), UsernamePasswordAuthenticationFilter.class);
 
         //세션 설정
         http

--- a/src/main/java/com/example/securityserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/securityserver/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join").permitAll()
+                        .requestMatchers("/login", "/", "/join", "/reissue").permitAll()
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated());
 

--- a/src/main/java/com/example/securityserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/securityserver/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.example.securityserver.config;
 
+import com.example.securityserver.jwt.CustomLogoutFilter;
 import com.example.securityserver.jwt.JWTFilter;
 import com.example.securityserver.jwt.JWTUtil;
 import com.example.securityserver.jwt.LoginFilter;
+import com.example.securityserver.repository.RefreshRepository;
 import com.example.securityserver.util.RefreshUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +16,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -23,12 +26,14 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JWTUtil jwtUtil;
     private final RefreshUtil refreshUtil;
+    private final RefreshRepository refreshRepository;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil, RefreshUtil refreshUtil) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil, RefreshUtil refreshUtil, RefreshRepository refreshRepository) {
 
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtUtil = jwtUtil;
         this.refreshUtil = refreshUtil;
+        this.refreshRepository = refreshRepository;
     }
 
     //AuthenticationManager Bean 등록
@@ -74,6 +79,8 @@ public class SecurityConfig {
         http
                 .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshUtil), UsernamePasswordAuthenticationFilter.class);
 
+        http
+                .addFilterBefore(new CustomLogoutFilter(refreshRepository, jwtUtil), LogoutFilter.class);
         //세션 설정
         http
                 .sessionManagement((session) -> session

--- a/src/main/java/com/example/securityserver/controller/ReissueController.java
+++ b/src/main/java/com/example/securityserver/controller/ReissueController.java
@@ -1,0 +1,23 @@
+package com.example.securityserver.controller;
+
+import com.example.securityserver.service.ReissueService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReissueController {
+
+    private final ReissueService reissueService;
+
+    public ReissueController(ReissueService reissueService){
+        this.reissueService = reissueService;
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response){
+        return reissueService.reissue(request, response);
+    }
+}

--- a/src/main/java/com/example/securityserver/controller/ReissueController.java
+++ b/src/main/java/com/example/securityserver/controller/ReissueController.java
@@ -12,6 +12,7 @@ public class ReissueController {
 
     private final ReissueService reissueService;
 
+
     public ReissueController(ReissueService reissueService){
         this.reissueService = reissueService;
     }

--- a/src/main/java/com/example/securityserver/domain/entity/RefreshEntity.java
+++ b/src/main/java/com/example/securityserver/domain/entity/RefreshEntity.java
@@ -1,0 +1,22 @@
+package com.example.securityserver.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class RefreshEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+    private String refresh;
+    private String expiration;
+}

--- a/src/main/java/com/example/securityserver/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/securityserver/jwt/CustomLogoutFilter.java
@@ -1,0 +1,105 @@
+package com.example.securityserver.jwt;
+
+import com.example.securityserver.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final RefreshRepository refreshRepository;
+    private final JWTUtil jwtUtil;
+
+    public CustomLogoutFilter(RefreshRepository refreshRepository, JWTUtil jwtUtil){
+        this.refreshRepository = refreshRepository;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        //path and method verify
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/logout$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+        //refresh null check
+        if (refresh == null) {
+
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/java/com/example/securityserver/jwt/JWTFilter.java
+++ b/src/main/java/com/example/securityserver/jwt/JWTFilter.java
@@ -2,6 +2,7 @@ package com.example.securityserver.jwt;
 
 import com.example.securityserver.domain.entity.UserEntity;
 import com.example.securityserver.dto.CustomUserDetails;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,6 +13,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 
 public class JWTFilter extends OncePerRequestFilter {
 
@@ -20,44 +22,54 @@ public class JWTFilter extends OncePerRequestFilter {
     public JWTFilter(JWTUtil jwtUtil){
         this.jwtUtil = jwtUtil;
     }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        //request에서 Authorization 헤더를 찾음
-        String authorization= request.getHeader("Authorization");
+        // 헤더에서 access키에 담긴 토큰을 꺼냄
+        String accessToken = request.getHeader("access");
 
-        //Authorization 헤더 검증
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
+        // 토큰이 없다면 다음 필터로 넘김
+        if (accessToken == null){
 
-            System.out.println("token null");
-            // 해당 필터를 종료하고 다음 필터로 요청과 응답을 전달한다.
             filterChain.doFilter(request, response);
 
-            //조건이 해당되면 메소드 종료 (필수)
             return;
         }
 
-        // Bearer 제거한 후의 토큰 획득
-        String token = authorization.split(" ")[1];
+        // 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e){
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("access token expired");
 
-        // 토큰 소멸 시간 검증
-        if(jwtUtil.isExpired(token)){
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
 
-            System.out.println("token expired");
-            filterChain.doFilter(request, response);
+        // 토큰이 access인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(accessToken);
 
-            //조건이 해당되면 메소드 종료 (필수)
+        if (!category.equals("access")){
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("invalid access token");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 
         //토큰에서 username과 role 획득
-        String username = jwtUtil.getUsername(token);
-        String role = jwtUtil.getRole(token);
+        String username = jwtUtil.getUsername(accessToken);
+        String role = jwtUtil.getRole(accessToken);
 
         //userEntity를 생성하여 값 set
         UserEntity userEntity = new UserEntity();
         userEntity.setUsername(username);
-        userEntity.setPassword("temppassword");
         userEntity.setRole(role);
 
         //UserDetails에 회원 정보 객체 담기 -> 스프링 시큐리티에서 요구하는 사용자 정보 형식을 따르기 위함

--- a/src/main/java/com/example/securityserver/jwt/JWTUtil.java
+++ b/src/main/java/com/example/securityserver/jwt/JWTUtil.java
@@ -20,6 +20,11 @@ public class JWTUtil {
 
     // jwt 검증 후 원하는 데이터 가져오기 함수
 
+    public String getCategory(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
     public String getUsername(String token) {
 
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
@@ -36,9 +41,10 @@ public class JWTUtil {
     }
 
     // jwt 생성 함수
-    public String createJwt(String username, String role, Long expiredMs) {
+    public String createJwt(String category, String username, String role, Long expiredMs) {
 
         return Jwts.builder()
+                .claim("category", category)
                 .claim("username", username)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))

--- a/src/main/java/com/example/securityserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/securityserver/jwt/LoginFilter.java
@@ -2,6 +2,7 @@ package com.example.securityserver.jwt;
 
 import com.example.securityserver.dto.CustomUserDetails;
 import com.example.securityserver.util.CookieUtil;
+import com.example.securityserver.util.RefreshUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,11 +22,13 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
     private final JWTUtil jwtUtil;
+    private final RefreshUtil refreshUtil;
 
-    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil) {
+    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil, RefreshUtil refreshUtil) {
 
         this.authenticationManager = authenticationManager;
         this.jwtUtil = jwtUtil;
+        this.refreshUtil = refreshUtil;
         setFilterProcessesUrl("/auth/login"); // 원하는 엔드포인트로 변경
     }
 
@@ -61,8 +64,11 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String role = auth.getAuthority();
 
         // 토큰 생성
-        String access = jwtUtil.createJwt("access", username, role, 60*60L);
-        String refresh = jwtUtil.createJwt("refresh", username, role, 60*60*24L);
+        String access = jwtUtil.createJwt("access", username, role, 600000L);
+        String refresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
+
+        // Refresh 토큰 저장
+        refreshUtil.addRefreshEntity(username, refresh, 86400000L);
 
         //응답 설정
         response.setHeader("access", access);

--- a/src/main/java/com/example/securityserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/securityserver/jwt/LoginFilter.java
@@ -1,6 +1,7 @@
 package com.example.securityserver.jwt;
 
 import com.example.securityserver.dto.CustomUserDetails;
+import com.example.securityserver.util.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -65,7 +66,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         //응답 설정
         response.setHeader("access", access);
-        response.addCookie(createCookie("refresh", refresh));
+        response.addCookie(CookieUtil.createCookie("refresh", refresh));
         response.setStatus(HttpStatus.OK.value());
     }
 
@@ -74,15 +75,4 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
         response.setStatus(401);
     }
-
-    private Cookie createCookie(String key, String value){
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(60*60*24);
-        // cookie.setSecure(true); //https
-        // cookie.setPath("/");
-        cookie.setHttpOnly(true);
-
-        return cookie;
-    }
-
 }

--- a/src/main/java/com/example/securityserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/securityserver/jwt/LoginFilter.java
@@ -2,8 +2,10 @@ package com.example.securityserver.jwt;
 
 import com.example.securityserver.dto.CustomUserDetails;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -44,30 +46,43 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     }
 
     // 로그인 성공시 실행하는 메소드 (여기서 JWT를 발급하면 됨)
-    // Authentication(getPrincipal(), getCredentials(), getAuthorities(), isAuthenticated(), getDetails())
+    // Authentication(getPrincipal(), getCredentials(), getAuthorities(), isAuthenticated(), getDetails(), getName())
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
-        // getPrincipal()을 통해 사용자의 주체 가져오기
-        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
 
-        String username = customUserDetails.getUsername();
+        // 유저 정보
+        String username = authentication.getName();
 
-        // getAuthorities()을 통해 사용자의 권한 가져오기
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         GrantedAuthority auth = iterator.next();
 
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(username, role, 60*60*10L);
+        // 토큰 생성
+        String access = jwtUtil.createJwt("access", username, role, 60*60L);
+        String refresh = jwtUtil.createJwt("refresh", username, role, 60*60*24L);
 
-        response.addHeader("Authorization", "Bearer " + token);
+        //응답 설정
+        response.setHeader("access", access);
+        response.addCookie(createCookie("refresh", refresh));
+        response.setStatus(HttpStatus.OK.value());
     }
 
     //로그인 실패시 실행하는 메소드
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
         response.setStatus(401);
+    }
+
+    private Cookie createCookie(String key, String value){
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*24);
+        // cookie.setSecure(true); //https
+        // cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
     }
 
 }

--- a/src/main/java/com/example/securityserver/repository/RefreshRepository.java
+++ b/src/main/java/com/example/securityserver/repository/RefreshRepository.java
@@ -1,0 +1,13 @@
+package com.example.securityserver.repository;
+
+import com.example.securityserver.domain.entity.RefreshEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
+
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+}

--- a/src/main/java/com/example/securityserver/service/ReissueService.java
+++ b/src/main/java/com/example/securityserver/service/ReissueService.java
@@ -1,6 +1,7 @@
 package com.example.securityserver.service;
 
 import com.example.securityserver.jwt.JWTUtil;
+import com.example.securityserver.util.CookieUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -60,9 +61,11 @@ public class ReissueService {
 
         //make new JWT
         String newAccess = jwtUtil.createJwt("access", username, role, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", username, role, 60*60*24L);
 
         //response
         response.setHeader("access", newAccess);
+        response.addCookie(CookieUtil.createCookie("refresh", newRefresh));
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/com/example/securityserver/service/ReissueService.java
+++ b/src/main/java/com/example/securityserver/service/ReissueService.java
@@ -1,7 +1,9 @@
 package com.example.securityserver.service;
 
 import com.example.securityserver.jwt.JWTUtil;
+import com.example.securityserver.repository.RefreshRepository;
 import com.example.securityserver.util.CookieUtil;
+import com.example.securityserver.util.RefreshUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,9 +16,13 @@ import org.springframework.stereotype.Service;
 public class ReissueService {
 
     private final JWTUtil jwtUtil;
+    private final RefreshUtil refreshUtil;
+    private final RefreshRepository refreshRepository;
 
-    public ReissueService(JWTUtil jwtUtil) {
+    public ReissueService(JWTUtil jwtUtil, RefreshUtil refreshUtil, RefreshRepository refreshRepository) {
         this.jwtUtil = jwtUtil;
+        this.refreshUtil = refreshUtil;
+        this.refreshRepository = refreshRepository;
     }
 
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
@@ -56,12 +62,23 @@ public class ReissueService {
             return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
         }
 
+        // DB에 저장되어 있는지 확인
+        Boolean isExistRefresh = refreshRepository.existsByRefresh(refresh);
+        if (!isExistRefresh) {
+            //response body
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
         String username = jwtUtil.getUsername(refresh);
         String role = jwtUtil.getRole(refresh);
 
         //make new JWT
         String newAccess = jwtUtil.createJwt("access", username, role, 600000L);
-        String newRefresh = jwtUtil.createJwt("refresh", username, role, 60*60*24L);
+        String newRefresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
+
+        //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
+        refreshRepository.deleteByRefresh(refresh);
+        refreshUtil.addRefreshEntity(username, newRefresh, 86400000L);
 
         //response
         response.setHeader("access", newAccess);

--- a/src/main/java/com/example/securityserver/service/ReissueService.java
+++ b/src/main/java/com/example/securityserver/service/ReissueService.java
@@ -1,0 +1,69 @@
+package com.example.securityserver.service;
+
+import com.example.securityserver.jwt.JWTUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReissueService {
+
+    private final JWTUtil jwtUtil;
+
+    public ReissueService(JWTUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+
+            //response status code
+            return new ResponseEntity<>("refresh token null", HttpStatus.BAD_REQUEST);
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            return new ResponseEntity<>("refresh token expired", HttpStatus.BAD_REQUEST);
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+
+        if (!category.equals("refresh")) {
+
+            //response status code
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        String username = jwtUtil.getUsername(refresh);
+        String role = jwtUtil.getRole(refresh);
+
+        //make new JWT
+        String newAccess = jwtUtil.createJwt("access", username, role, 600000L);
+
+        //response
+        response.setHeader("access", newAccess);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/securityserver/util/CookieUtil.java
+++ b/src/main/java/com/example/securityserver/util/CookieUtil.java
@@ -1,0 +1,16 @@
+package com.example.securityserver.util;
+
+import jakarta.servlet.http.Cookie;
+
+public class CookieUtil {
+
+    public static Cookie createCookie(String key, String value){
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*24);
+        // cookie.setSecure(true); //https
+        // cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/com/example/securityserver/util/RefreshUtil.java
+++ b/src/main/java/com/example/securityserver/util/RefreshUtil.java
@@ -1,0 +1,28 @@
+package com.example.securityserver.util;
+
+import com.example.securityserver.domain.entity.RefreshEntity;
+import com.example.securityserver.repository.RefreshRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class RefreshUtil {
+
+    private final RefreshRepository refreshRepository;
+
+    public RefreshUtil(RefreshRepository refreshRepository){
+        this.refreshRepository = refreshRepository;
+    }
+
+    public void addRefreshEntity(String username, String refresh, Long expiredMs){
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshEntity refreshEntity = new RefreshEntity();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+}


### PR DESCRIPTION
- access, refresh 토큰 사용한 다중 토큰 jwt
- CustomLogoutFilter 설정 후 로그아웃 구현
- refresh 서버 측 주도권을 위한 RefreshEntity DB 저장
- reissue API를 사용한 refresh 토큰으로 access 토큰 재발급 받기